### PR TITLE
Add basic lint and format tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 88
+target-version = ['py312']
+
+[tool.ruff]
+line-length = 88
+target-version = 'py312'
+
+[tool.ruff.lint]
+select = ['E', 'F', 'I']
+ignore = []
+
+[tool.ruff.format]
+quote-style = 'single'
+indent-style = 'space'
+skip-magic-trailing-comma = false
+line-ending = 'lf'


### PR DESCRIPTION
## Summary
- configure ruff and black with Python 3.12 and line length 88

## Testing
- `black --check .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_687d56d8f12c832c83f0daf11646bae6