### PR TITLE
feat: add local setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # pkm-ai-interface
+
+This repository contains a proof-of-concept proxy for Roam Research built around the `roam-research-mcp` package.
+
+## Development
+
+1. Run `scripts/setup.sh` to install Docker (requires sudo privileges).
+2. Build the Lambda container image:
+   ```
+   docker build -t roam-mcp-proxy ./src
+   ```
+3. Optional: run the container locally (requires Docker daemon):
+   ```
+   docker run --rm -p 9000:8080 roam-mcp-proxy
+   ```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Simple setup script to install Docker on Ubuntu-based systems.
+# Only runs if docker command is not found.
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[setup] Installing Docker..."
+    apt-get update
+    apt-get install -y docker.io
+fi
+
+DOCKER_VERSION=$(docker --version 2>/dev/null || echo "not installed")
+
+echo "[setup] Docker version: $DOCKER_VERSION"
+
+echo "Docker installed. To build the container:" >&2
+echo "  docker build -t roam-mcp-proxy ./src" >&2

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/python:3.12-2025.03.11-arm64
+
+RUN pip install --no-cache-dir roam-research-mcp==0.3.*
+
+COPY entrypoint.sh ./
+
+CMD ["entrypoint.handler"]

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -euo pipefail
+
+# Optionally fetch token from AWS Secrets Manager if SECRET_ID is set
+if [ -n "${SECRET_ID:-}" ]; then
+    TOKEN_JSON=$(aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query SecretString --output text)
+    if command -v jq >/dev/null 2>&1; then
+        export ROAM_API_TOKEN=$(echo "$TOKEN_JSON" | jq -r '.ROAM_API_TOKEN')
+    else
+        export ROAM_API_TOKEN=$(echo "$TOKEN_JSON" | sed -n 's/.*"ROAM_API_TOKEN"[ :]\{1,2\}"\([^"]*\)".*/\1/p')
+    fi
+fi
+
+# Default base URL for MCP server
+export ROAM_API_BASE=${ROAM_API_BASE:-"http://0.0.0.0:8088"}
+
+exec roam-research-mcp


### PR DESCRIPTION
## Summary
- document how to build the Lambda container
- add setup script for installing Docker

## Testing
- `bash scripts/setup.sh`
- `docker build -t roam-mcp-proxy ./src` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687d5ad19fe8832ca4d7ac3ca081ae54