### PR TITLE
feat: add secrets manager loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # pkm-ai-interface
+
+Utilities and examples for integrating the Roam MCP proxy with custom
+GPT Actions. The repository follows the style guidelines defined in the
+[PRD](.taskmaster/prd.md).
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+2. Run the unit tests:
+   ```bash
+   pytest
+   ```
+   Moto is used to mock AWS services.
+
+3. Format and lint the code:
+   ```bash
+   ruff .
+   black .
+   ```
+
+See [`docs/SECRET_RETRIEVAL.md`](docs/SECRET_RETRIEVAL.md) for
+information about the secret loader utility.

--- a/docs/SECRET_RETRIEVAL.md
+++ b/docs/SECRET_RETRIEVAL.md
@@ -1,0 +1,13 @@
+# Secret Retrieval Utility
+
+This project includes a small helper used by AWS Lambda functions to fetch JSON
+secrets from AWS Secrets Manager.
+
+```
+from src import token_loader
+
+secret = token_loader.load("my/secret", region_name="us-east-1")
+```
+
+The function will raise `TokenLoaderError` if the secret cannot be obtained or
+the value is not valid JSON.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+boto3
+moto
+pytest
+ruff
+black

--- a/src/token_loader.py
+++ b/src/token_loader.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+
+class TokenLoaderError(Exception):
+    """Raised when the token cannot be retrieved from Secrets Manager."""
+
+
+def load(secret_name: str, region_name: str | None = None) -> Dict[str, Any]:
+    """Load and return a secret from AWS Secrets Manager.
+
+    Parameters
+    ----------
+    secret_name: str
+        Name of the secret in AWS Secrets Manager.
+    region_name: str | None
+        AWS region. Uses default region if ``None``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed JSON value stored in the secret.
+
+    Raises
+    ------
+    TokenLoaderError
+        If the secret cannot be fetched or parsed.
+    """
+
+    client = boto3.client("secretsmanager", region_name=region_name)
+    try:
+        response = client.get_secret_value(SecretId=secret_name)
+    except (ClientError, BotoCoreError) as exc:
+        raise TokenLoaderError(f"Unable to fetch secret: {secret_name}") from exc
+
+    secret_string = response.get("SecretString")
+    if secret_string is None:
+        raise TokenLoaderError("SecretString is empty")
+
+    try:
+        return json.loads(secret_string)
+    except json.JSONDecodeError as exc:
+        raise TokenLoaderError("SecretString contains invalid JSON") from exc

--- a/tests/unit/test_token_loader.py
+++ b/tests/unit/test_token_loader.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+
+import boto3
+from moto import mock_aws
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import pytest
+
+from src import token_loader
+
+
+@mock_aws
+def test_load_returns_secret_json():
+    client = boto3.client("secretsmanager", region_name="us-east-1")
+    secret_name = "my/secret"
+    secret_value = {"token": "abc123"}
+    client.create_secret(Name=secret_name, SecretString=json.dumps(secret_value))
+
+    result = token_loader.load(secret_name, region_name="us-east-1")
+
+    assert result == secret_value
+
+
+@mock_aws
+def test_load_raises_on_missing_secret():
+    with pytest.raises(token_loader.TokenLoaderError):
+        token_loader.load("missing", region_name="us-east-1")
+
+
+@mock_aws
+def test_load_raises_on_invalid_json():
+    client = boto3.client("secretsmanager", region_name="us-east-1")
+    secret_name = "bad/secret"
+    client.create_secret(Name=secret_name, SecretString="not-json")
+
+    with pytest.raises(token_loader.TokenLoaderError):
+        token_loader.load(secret_name, region_name="us-east-1")


### PR DESCRIPTION
## Summary
- implement a small helper for fetching secrets from AWS Secrets Manager
- add unit tests for token loader using moto
- document secret retrieval utility
- update README with development and testing steps

## Testing
- `ruff check .`
- `black .`
- `pytest tests/unit/test_token_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5f5f508c832caa40272a61eb8e9f