### PR TITLE
test: automate openapi generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # pkm-ai-interface
+
+Utility scripts and docs for working with the Roam MCP proxy.
+
+## OpenAPI schema generation
+
+1. Start the MCP container locally:
+   ```bash
+   docker run -p 8088:8088 roam-research-mcp:0.3.x
+   ```
+2. Run the helper script (optionally set `MCP_URL` or `DOCS_DIR`):
+   ```bash
+   MCP_URL=http://localhost:8088/openapi.json \
+   ./scripts/generate_openapi.sh
+   ```
+   It fetches the schema from the container and writes a trimmed version to
+   `docs/openapi_trim.json` containing only the endpoints required by the Custom GPT.
+
+## Testing
+
+Run the script manually and verify that `docs/openapi_trim.json` is created.
+For an automated check, run:
+```bash
+pytest -k generate_openapi
+```

--- a/docs/openapi_trim.json
+++ b/docs/openapi_trim.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Roam MCP API",
+    "version": "0.3"
+  },
+  "paths": {
+    "/roam_process_batch_actions": {
+      "post": {
+        "summary": "Process Roam batch actions",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/roam_fetch_page_by_title": {
+      "get": {
+        "summary": "Fetch Roam page by title",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/analytics/log": {
+      "post": {
+        "summary": "Log analytics events",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": null
+}

--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# allow overriding docs output directory for testing
+DOCS_DIR="${DOCS_DIR:-$REPO_ROOT/docs}"
+mkdir -p "$DOCS_DIR"
+
+RAW_SPEC="$DOCS_DIR/roam_mcp_openapi.json"
+TRIM_SPEC="$DOCS_DIR/openapi_trim.json"
+
+# allow overriding MCP URL (default http://localhost:8088/openapi.json)
+MCP_URL="${MCP_URL:-http://localhost:8088/openapi.json}"
+
+echo "Fetching OpenAPI spec from MCP container at $MCP_URL..."
+curl -sf "$MCP_URL" -o "$RAW_SPEC"
+
+echo "Trimming spec to required endpoints..."
+jq '{
+  openapi: .openapi,
+  info: .info,
+  paths: {
+    "/roam_process_batch_actions": .paths["/roam_process_batch_actions"],
+    "/roam_fetch_page_by_title": .paths["/roam_fetch_page_by_title"],
+    "/analytics/log": .paths["/analytics/log"]
+  },
+  components: .components
+}' "$RAW_SPEC" > "$TRIM_SPEC"
+
+echo "Trimmed schema written to $TRIM_SPEC"

--- a/tests/data/openapi.json
+++ b/tests/data/openapi.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.0.0",
+  "info": {"title": "Roam MCP API", "version": "0.3"},
+  "paths": {
+    "/roam_process_batch_actions": {"post": {}},
+    "/roam_fetch_page_by_title": {"get": {}},
+    "/analytics/log": {"post": {}},
+    "/extra/endpoint": {"get": {}}
+  },
+  "components": null
+}

--- a/tests/test_generate_openapi.py
+++ b/tests/test_generate_openapi.py
@@ -1,0 +1,58 @@
+import json
+import os
+import subprocess
+import tempfile
+import http.server
+import socketserver
+import threading
+from pathlib import Path
+
+import pytest
+
+
+def run_server(tmpdir):
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(tmpdir), **kwargs)
+
+    server = socketserver.TCPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return server, thread
+
+
+def test_generate_openapi(tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    # copy openapi.json to tmp path
+    src = data_dir / "openapi.json"
+    dest = tmp_path / "openapi.json"
+    dest.write_bytes(src.read_bytes())
+
+    server, thread = run_server(tmp_path)
+    try:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        env = {
+            **os.environ,
+            "MCP_URL": f"http://localhost:{server.server_address[1]}/openapi.json",
+            "DOCS_DIR": str(docs_dir),
+        }
+        subprocess.run(
+            [
+                "bash",
+                str(Path(__file__).parents[1] / "scripts" / "generate_openapi.sh"),
+            ],
+            check=True,
+            env=env,
+        )
+        trimmed = json.loads((docs_dir / "openapi_trim.json").read_text())
+    finally:
+        server.shutdown()
+        thread.join()
+
+    assert set(trimmed["paths"].keys()) == {
+        "/roam_process_batch_actions",
+        "/roam_fetch_page_by_title",
+        "/analytics/log",
+    }


### PR DESCRIPTION
## Summary
- allow generate_openapi.sh to override URL and output directory
- document the variables in README
- add pytest to verify trimmed schema generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d79e9e470832cbbbb661b2abe43e9