### PR TITLE
feat: implement analytics logging with stubbed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # pkm-ai-interface
+
+This repository contains a minimal AWS Lambda application used as a proof of
+concept for the Roam MCP proxy. The function exposes an `/analytics/log`
+endpoint that records structured events to Amazon Kinesis Firehose.
+
+## Usage
+
+The Lambda expects the environment variable `FIREHOSE_STREAM_NAME` to be set to
+the name of the delivery stream. Requests should include a valid Cognito
+`sub` claim which is used as the `user_id` for analytics.
+
+```
+POST /analytics/log
+{
+  "action": "test"
+}
+```
+
+A `timestamp` is added server-side and the record is forwarded to Firehose.
+
+## Development
+
+Install dependencies and run tests with `pytest`:
+
+```
+pip install boto3 moto[firehose]
+pytest
+```
+
+## TODO
+
+Unit tests currently stub the Firehose client. Future work includes:
+
+- Add integration tests against a real Firehose endpoint or moto-based mock.
+- Expand IAM policies and Terraform to support production deployment.
+- Remove dummy credentials and use environment-specific configuration.

--- a/infra/analytics_firehose.tf
+++ b/infra/analytics_firehose.tf
@@ -1,0 +1,32 @@
+# Terraform snippet for analytics Firehose
+resource "aws_kinesis_firehose_delivery_stream" "analytics" {
+  name        = "analytics-stream"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.analytics.arn
+  }
+}
+
+resource "aws_iam_role" "firehose" {
+  name = "firehose-role"
+  assume_role_policy = data.aws_iam_policy_document.firehose_assume.json
+}
+
+resource "aws_iam_policy" "firehose_write" {
+  name   = "firehose-write-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action   = ["firehose:PutRecord"]
+      Effect   = "Allow"
+      Resource = aws_kinesis_firehose_delivery_stream.analytics.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_firehose" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.firehose_write.arn
+}

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from .logger import log_event
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Basic router for Lambda events."""
+    path = event.get("rawPath") or event.get("path")
+    method = event.get("requestContext", {}).get("http", {}).get("method") or event.get(
+        "httpMethod"
+    )
+
+    if method == "POST" and path == "/analytics/log":
+        body = event.get("body")
+        try:
+            payload = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"detail": "Invalid JSON"}),
+            }
+
+        user_id = (
+            event.get("requestContext", {})
+            .get("authorizer", {})
+            .get("claims", {})
+            .get("sub")
+        )
+
+        data = {
+            "user_id": user_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "payload": payload,
+        }
+        log_event(data)
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"status": "ok"}),
+        }
+
+    return {
+        "statusCode": 404,
+        "body": json.dumps({"detail": "Not found"}),
+    }

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,0 +1,18 @@
+import json
+import os
+import boto3
+
+firehose_client = boto3.client(
+    "firehose", region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+)
+
+
+def log_event(data, stream_name=None, client=None):
+    """Send a single analytics record to Kinesis Firehose."""
+    client = client or firehose_client
+    stream = stream_name or os.getenv("FIREHOSE_STREAM_NAME")
+    if not stream:
+        raise RuntimeError("FIREHOSE_STREAM_NAME not set")
+
+    record = {"Data": json.dumps(data) + "\n"}
+    client.put_record(DeliveryStreamName=stream, Record=record)

--- a/tests/test_analytics_logging.py
+++ b/tests/test_analytics_logging.py
@@ -1,0 +1,61 @@
+import os
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import boto3
+from botocore.stub import Stubber
+
+from src import handler, logger
+
+
+def _sample_event() -> Dict[str, Any]:
+    return {
+        "rawPath": "/analytics/log",
+        "body": json.dumps({"action": "test"}),
+        "requestContext": {
+            "http": {"method": "POST"},
+            "authorizer": {"claims": {"sub": "user123"}},
+        },
+    }
+
+
+def test_lambda_logs_to_firehose(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    monkeypatch.setenv("FIREHOSE_STREAM_NAME", "stream")
+
+    client = boto3.client("firehose", region_name="us-east-1")
+    stubber = Stubber(client)
+    monkeypatch.setattr(logger, "firehose_client", client)
+
+    fixed_time = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_time
+
+    monkeypatch.setattr(handler, "datetime", FixedDatetime)
+
+    expected_payload = {
+        "user_id": "user123",
+        "timestamp": fixed_time.isoformat(),
+        "payload": {"action": "test"},
+    }
+    expected_params = {
+        "DeliveryStreamName": "stream",
+        "Record": {"Data": json.dumps(expected_payload) + "\n"},
+    }
+    stubber.add_response("put_record", {"RecordId": "1"}, expected_params)
+
+    with stubber:
+        event = _sample_event()
+        resp = handler.lambda_handler(event, None)
+
+    assert resp["statusCode"] == 200
+    stubber.assert_no_pending_responses()


### PR DESCRIPTION
## Summary
- implement analytics endpoint with Firehose logging
- use botocore Stubber in unit test
- document remaining TODO items in README

## Testing
- `ruff check src tests`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d7fdb25e0832c84bd2ee0207adedf