### PR TITLE
Add fetch and append smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment variables for pkm-ai-interface
+
+# Base URL of your deployed Roam MCP proxy
+ROAM_API_BASE=https://example.execute-api.aws-region.amazonaws.com/prod
+
+# Authorization token for the Roam API
+ROAM_API_TOKEN=changeme

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # pkm-ai-interface
+
+This repository holds tests and utilities for the Roam MCP proxy proof of concept.
+
+## Configuration
+
+Copy `.env.example` to `.env` and provide the values for the variables below:
+
+- `ROAM_API_BASE` – Base URL of your deployed MCP proxy
+- `ROAM_API_TOKEN` – API token used for Authorization header
+
+## Running smoke tests
+
+The `tests/smoke/test_fetch_and_append.py` test issues a simple create-and-fetch workflow against a deployed proxy. Export the base URL of your deployment as `ROAM_API_BASE` (or load it from a `.env` file) and run:
+
+```bash
+pytest tests/smoke/test_fetch_and_append.py -k prod
+```
+
+Refer to `.taskmaster/prd.md` for the full product requirements and additional implementation notes.
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    prod: smoke tests run against deployed environment
+

--- a/tests/smoke/test_fetch_and_append.py
+++ b/tests/smoke/test_fetch_and_append.py
@@ -1,0 +1,27 @@
+import os
+import requests
+import uuid
+import pytest
+
+pytestmark = pytest.mark.prod
+
+BASE = os.getenv("ROAM_API_BASE")
+
+
+def test_fetch_and_append():
+    title = "TestPage-" + uuid.uuid4().hex[:6]
+
+    # 1) create page
+    r = requests.post(
+        f"{BASE}/roam_process_batch_actions",
+        json={"actions": [{"create_page": {"title": title}}]},
+    )
+    assert r.status_code == 200
+
+    # 2) fetch page back
+    page = requests.get(
+        f"{BASE}/roam_fetch_page_by_title",
+        params={"title": title},
+    )
+    assert page.json()["title"] == title
+


### PR DESCRIPTION
## Summary
- add smoke test skeleton for fetching a page and appending in Roam
- document how to run the smoke test in README
- include `.env.example` with required environment variable placeholders
- register `prod` pytest mark

## Testing
- `pytest tests/smoke/test_fetch_and_append.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` then `pytest tests/smoke/test_fetch_and_append.py -k prod -q` *(fails: MissingSchema due to unset ROAM_API_BASE)*

------
https://chatgpt.com/codex/tasks/task_e_687d9397f8dc832c9eb36b71e85c0486