### PR TITLE
Add CI workflow with lint/test, security and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  PYTHON_VERSION: "3.12"
+  DEPLOY_TOOL: ${{ vars.DEPLOY_TOOL || 'sam' }}
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff black pytest
+      - name: Lint
+        run: |
+          ruff .
+          black --check .
+      - name: Test
+        run: |
+          pytest -q
+
+  security:
+    runs-on: ubuntu-latest
+    needs: lint-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install security tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+      - name: Bandit Scan
+        run: bandit -r .
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [lint-test, security]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Install deployment tools
+        run: |
+          python -m pip install --upgrade pip
+          if [ "$DEPLOY_TOOL" = "terraform" ]; then
+            pip install terraform
+          else
+            pip install aws-sam-cli
+          fi
+      - name: Deploy
+        env:
+          DEPLOY_TOOL: ${{ env.DEPLOY_TOOL }}
+        run: |
+          if [ "$DEPLOY_TOOL" = "terraform" ]; then
+            terraform init
+            terraform apply -auto-approve
+          else
+            sam deploy --guided --no-confirm-changeset
+          fi
+      - uses: 8398a7/action-slack@v3
+        if: always()
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # pkm-ai-interface
+
+This repository provides a minimal proof of concept for interacting with Roam Research via a middle layer.
+
+## CI/CD Strategy
+
+The `ci.yml` workflow under `.github/workflows` runs on every pull request and push to `main`.
+
+1. **Lint & Test** – installs dependencies, runs `ruff`, `black --check`, and `pytest`.
+2. **Security** – executes `bandit` to detect common Python issues.
+3. **Deploy** – on pushes to `main` the project deploys using either `sam deploy --guided` or `terraform apply` depending on the `DEPLOY_TOOL` variable. AWS credentials are provided through `aws-actions/configure-aws-credentials`.
+4. **Notifications** – results are posted to Slack via the `SLACK_WEBHOOK_URL` secret.
+
+### Future Enhancements
+
+- Add CodeQL scanning.
+- Create per-PR preview stacks.
+- Expand tests for the analytics logging endpoint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- expand README with CI/CD strategy and future work
- update GitHub Actions workflow
  - run lint, test, security scan
  - deploy using SAM or Terraform
  - send Slack notifications
  - use AWS credentials action

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687db32e2204832c9b8df80ee145c443