### PR TITLE
feat: add script to generate trimmed openapi spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ For an automated check, run:
 pytest -k generate_openapi
 ```
 
+See [`docs/OPENAPI_SPEC.md`](docs/OPENAPI_SPEC.md) for an overview of the trimming approach and a description of the included endpoints.
+
 The long-term goal is a production-ready proxy with full observability and analytics of all calls.
 
 ## AWS Lambda Application

--- a/docs/OPENAPI_SPEC.md
+++ b/docs/OPENAPI_SPEC.md
@@ -1,0 +1,23 @@
+# OpenAPI Approach and Endpoints
+
+This project exposes a limited subset of the Roam MCP API. We generate a trimmed OpenAPI schema that contains only the endpoints required by the Custom GPT.
+
+## Generating the schema
+
+Run the helper script against a running MCP container:
+
+```bash
+MCP_URL=http://localhost:8088/openapi.json ./scripts/generate_openapi.sh
+```
+
+The script downloads the full OpenAPI document, filters it down to the required paths, and writes the result to `docs/openapi_trim.json`.
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/roam_process_batch_actions` | `POST` | Apply a batch of write operations to the Roam graph. |
+| `/roam_fetch_page_by_title` | `GET`  | Retrieve a page by its title. |
+| `/analytics/log`            | `POST` | Record an analytics event. |
+
+See `openapi_trim.json` for the machine-readable schema.

--- a/docs/openapi_trim.json
+++ b/docs/openapi_trim.json
@@ -6,34 +6,13 @@
   },
   "paths": {
     "/roam_process_batch_actions": {
-      "post": {
-        "summary": "Process Roam batch actions",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
+      "post": {}
     },
     "/roam_fetch_page_by_title": {
-      "get": {
-        "summary": "Fetch Roam page by title",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
+      "get": {}
     },
     "/analytics/log": {
-      "post": {
-        "summary": "Log analytics events",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
+      "post": {}
     }
   },
   "components": null

--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -6,13 +6,13 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 DOCS_DIR="${DOCS_DIR:-$REPO_ROOT/docs}"
 mkdir -p "$DOCS_DIR"
 
-RAW_SPEC="$DOCS_DIR/roam_mcp_openapi.json"
 TRIM_SPEC="$DOCS_DIR/openapi_trim.json"
 
 # allow overriding MCP URL (default http://localhost:8088/openapi.json)
 MCP_URL="${MCP_URL:-http://localhost:8088/openapi.json}"
 
 echo "Fetching OpenAPI spec from MCP container at $MCP_URL..."
+RAW_SPEC="$(mktemp)"
 curl -sf "$MCP_URL" -o "$RAW_SPEC"
 
 echo "Trimming spec to required endpoints..."
@@ -26,5 +26,6 @@ jq '{
   },
   components: .components
 }' "$RAW_SPEC" > "$TRIM_SPEC"
+rm "$RAW_SPEC"
 
 echo "Trimmed schema written to $TRIM_SPEC"


### PR DESCRIPTION
## Summary
- add helper script to fetch and trim the MCP's OpenAPI schema
- store generated OpenAPI schema with only the endpoints required by the custom GPT
- document the generation approach and available endpoints

## Testing
- `MCP_URL=file://$PWD/tests/data/openapi.json DOCS_DIR=$(mktemp -d) ./scripts/generate_openapi.sh`
- `pytest tests/test_generate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_68a39d98ee5c832c9f8cdd8541ce91fe