### PR TITLE
Add fetch/append smoke test and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Lint
+        run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install SAM CLI
+        run: pip install aws-sam-cli
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: |
+          sam build
+          sam deploy --guided
+          # Alternatively, uncomment to use Terraform
+          # terraform init
+          # terraform apply -auto-approve

--- a/tests/smoke/test_fetch_and_append.py
+++ b/tests/smoke/test_fetch_and_append.py
@@ -1,14 +1,16 @@
 import os
-import requests
 import uuid
+
 import pytest
+import requests
 
 pytestmark = pytest.mark.prod
 
 BASE = os.getenv("ROAM_API_BASE")
 
 
-def test_fetch_and_append():
+@pytest.mark.skipif(BASE is None, reason="ROAM_API_BASE not set")
+def test_fetch_and_append() -> None:
     title = "TestPage-" + uuid.uuid4().hex[:6]
 
     # 1) create page
@@ -18,10 +20,28 @@ def test_fetch_and_append():
     )
     assert r.status_code == 200
 
-    # 2) fetch page back
+    # 2) append a block
+    r = requests.post(
+        f"{BASE}/roam_process_batch_actions",
+        json={
+            "actions": [
+                {
+                    "append_block": {
+                        "location": {"page": {"title": title}},
+                        "string": "hello world",
+                    }
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200
+
+    # 3) fetch page back and verify
     page = requests.get(
         f"{BASE}/roam_fetch_page_by_title",
         params={"title": title},
     )
-    assert page.json()["title"] == title
+    data = page.json()
+    assert data["title"] == title
+    assert any(child["string"] == "hello world" for child in data.get("children", []))
 


### PR DESCRIPTION
## Summary
- add fetch and append smoke test using ROAM_API_BASE
- configure GitHub Actions to lint, test and deploy via SAM

## Testing
- `ruff check tests/smoke/test_fetch_and_append.py`
- `pytest tests/smoke/test_fetch_and_append.py -q` *(fails: skipped, missing ROAM_API_BASE)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e0f05c28832cb828737ab309b57a