### PR TITLE
Add Roam MCP proxy endpoints and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The long-term goal is a production-ready proxy with full observability and analy
 
 ## AWS Lambda Application
 
-This repository contains a minimal AWS Lambda application used as a proof of concept for the Roam MCP proxy. The function exposes an `/analytics/log` endpoint that records structured events to Amazon Kinesis Firehose.
+This repository contains a minimal AWS Lambda application used as a proof of concept for the Roam MCP proxy. In addition to an `/analytics/log` endpoint that records structured events to Amazon Kinesis Firehose, the function proxies requests under `/roam_*` to the `roam-research-mcp` server. This enables the GPT to read pages, search blocks, and append content within the Roam graph.
 
 The Lambda expects the environment variable `FIREHOSE_STREAM_NAME` to be set to the name of the delivery stream. Requests should include a valid Cognito `sub` claim which is used as the `user_id` for analytics.
 

--- a/docs/OPENAPI_SPEC.md
+++ b/docs/OPENAPI_SPEC.md
@@ -18,6 +18,7 @@ The script downloads the full OpenAPI document, filters it down to the required 
 |------|--------|-------------|
 | `/roam_process_batch_actions` | `POST` | Apply a batch of write operations to the Roam graph. |
 | `/roam_fetch_page_by_title` | `GET`  | Retrieve a page by its title. |
+| `/roam_search_blocks` | `GET` | Search blocks matching a query string. |
 | `/analytics/log`            | `POST` | Record an analytics event. |
 
 See `openapi_trim.json` for the machine-readable schema.

--- a/docs/openapi_trim.json
+++ b/docs/openapi_trim.json
@@ -11,6 +11,9 @@
     "/roam_fetch_page_by_title": {
       "get": {}
     },
+    "/roam_search_blocks": {
+      "get": {}
+    },
     "/analytics/log": {
       "post": {}
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ moto
 pytest
 ruff
 black
+requests

--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -22,6 +22,7 @@ jq '{
   paths: {
     "/roam_process_batch_actions": .paths["/roam_process_batch_actions"],
     "/roam_fetch_page_by_title": .paths["/roam_fetch_page_by_title"],
+    "/roam_search_blocks": .paths["/roam_search_blocks"],
     "/analytics/log": .paths["/analytics/log"]
   },
   components: .components

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,10 +1,38 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
+import requests
+
 from .logger import log_event
+
+ROAM_API_BASE = os.environ.get("ROAM_API_BASE", "http://0.0.0.0:8088")
+ROAM_API_TOKEN = os.environ.get("ROAM_API_TOKEN")
+
+
+def _proxy_to_roam(event: Dict[str, Any], path: str, method: str) -> Dict[str, Any]:
+    url = f"{ROAM_API_BASE}{path}"
+    qs = event.get("rawQueryString") or ""
+    if not qs and event.get("queryStringParameters"):
+        from urllib.parse import urlencode
+
+        qs = urlencode(event.get("queryStringParameters", {}))
+    if qs:
+        url = f"{url}?{qs}"
+    headers = {}
+    if ROAM_API_TOKEN:
+        headers["Authorization"] = f"Bearer {ROAM_API_TOKEN}"
+    req_headers = event.get("headers") or {}
+    if "Content-Type" in req_headers:
+        headers["Content-Type"] = req_headers["Content-Type"]
+    elif event.get("body"):
+        headers["Content-Type"] = "application/json"
+    body = event.get("body")
+    response = requests.request(method, url, data=body, headers=headers)
+    return {"statusCode": response.status_code, "body": response.text}
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -13,6 +41,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     method = event.get("requestContext", {}).get("http", {}).get("method") or event.get(
         "httpMethod"
     )
+
+    if path and path.startswith("/roam_"):
+        return _proxy_to_roam(event, path, method)
 
     if method == "POST" and path == "/analytics/log":
         body = event.get("body")

--- a/tests/data/openapi.json
+++ b/tests/data/openapi.json
@@ -4,6 +4,7 @@
   "paths": {
     "/roam_process_batch_actions": {"post": {}},
     "/roam_fetch_page_by_title": {"get": {}},
+    "/roam_search_blocks": {"get": {}},
     "/analytics/log": {"post": {}},
     "/extra/endpoint": {"get": {}}
   },

--- a/tests/test_analytics_logging.py
+++ b/tests/test_analytics_logging.py
@@ -1,4 +1,8 @@
 import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
 

--- a/tests/test_generate_openapi.py
+++ b/tests/test_generate_openapi.py
@@ -51,5 +51,6 @@ def test_generate_openapi(tmp_path):
     assert set(trimmed["paths"].keys()) == {
         "/roam_process_batch_actions",
         "/roam_fetch_page_by_title",
+        "/roam_search_blocks",
         "/analytics/log",
     }

--- a/tests/test_roam_proxy.py
+++ b/tests/test_roam_proxy.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src import handler
+
+
+class DummyResponse:
+    def __init__(self, status_code: int = 200, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+def _invoke(event, monkeypatch):
+    called = {}
+
+    def fake_request(method, url, data=None, headers=None):
+        called["method"] = method
+        called["url"] = url
+        called["data"] = data
+        called["headers"] = headers or {}
+        return DummyResponse(200, '{"ok": true}')
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    resp = handler.lambda_handler(event, None)
+    return resp, called
+
+
+def test_fetch_page_by_title(monkeypatch):
+    monkeypatch.setattr(handler, "ROAM_API_BASE", "http://mcp")
+    monkeypatch.setattr(handler, "ROAM_API_TOKEN", "token")
+    event = {
+        "rawPath": "/roam_fetch_page_by_title",
+        "rawQueryString": "title=Foo",
+        "requestContext": {"http": {"method": "GET"}},
+        "headers": {"Content-Type": "application/json"},
+    }
+    resp, called = _invoke(event, monkeypatch)
+    assert called["url"] == "http://mcp/roam_fetch_page_by_title?title=Foo"
+    assert called["method"] == "GET"
+    assert called["headers"]["Authorization"] == "Bearer token"
+    assert resp["statusCode"] == 200
+    assert resp["body"] == '{"ok": true}'
+
+
+def test_process_batch_actions(monkeypatch):
+    monkeypatch.setattr(handler, "ROAM_API_BASE", "http://mcp")
+    event = {
+        "rawPath": "/roam_process_batch_actions",
+        "body": '{"actions": []}',
+        "requestContext": {"http": {"method": "POST"}},
+        "headers": {"Content-Type": "application/json"},
+    }
+    resp, called = _invoke(event, monkeypatch)
+    assert called["url"] == "http://mcp/roam_process_batch_actions"
+    assert called["method"] == "POST"
+    assert called["data"] == '{"actions": []}'
+    assert resp["statusCode"] == 200
+
+
+def test_search_blocks(monkeypatch):
+    monkeypatch.setattr(handler, "ROAM_API_BASE", "http://mcp")
+    event = {
+        "rawPath": "/roam_search_blocks",
+        "rawQueryString": "query=test",
+        "requestContext": {"http": {"method": "GET"}},
+    }
+    resp, called = _invoke(event, monkeypatch)
+    assert called["url"] == "http://mcp/roam_search_blocks?query=test"
+    assert called["method"] == "GET"
+    assert resp["statusCode"] == 200


### PR DESCRIPTION
## Summary
- Proxy `/roam_*` requests from the Lambda handler to the `roam-research-mcp` server
- Document new `/roam_search_blocks` endpoint and updated OpenAPI schema
- Add unit tests covering Roam proxy routes and OpenAPI trimming

## Testing
- `ruff check .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3f78415b0832c88716a67b1dda3bb