### PR TITLE
Configure analytics Firehose pipeline with transformation

### DIFF
--- a/infra/analytics_firehose.tf
+++ b/infra/analytics_firehose.tf
@@ -1,32 +1,109 @@
-# # Terraform snippet for analytics Firehose
-# resource "aws_kinesis_firehose_delivery_stream" "analytics" {
-#   name        = "analytics-stream"
-#   destination = "s3"
-# 
-#   s3_configuration {
-#     role_arn   = aws_iam_role.firehose.arn
-#     bucket_arn = aws_s3_bucket.analytics.arn
-#   }
-# }
-# 
-# resource "aws_iam_role" "firehose" {
-#   name = "firehose-role"
-#   assume_role_policy = data.aws_iam_policy_document.firehose_assume.json
-# }
-# 
-# resource "aws_iam_policy" "firehose_write" {
-#   name   = "firehose-write-policy"
-#   policy = jsonencode({
-#     Version = "2012-10-17"
-#     Statement = [{
-#       Action   = ["firehose:PutRecord"]
-#       Effect   = "Allow"
-#       Resource = aws_kinesis_firehose_delivery_stream.analytics.arn
-#     }]
-#   })
-# }
-# 
-# resource "aws_iam_role_policy_attachment" "lambda_firehose" {
-#   role       = aws_iam_role.lambda_exec.name
-#   policy_arn = aws_iam_policy.firehose_write.arn
-# }
+data "aws_iam_policy_document" "firehose_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "analytics" {
+  bucket_prefix = "pkm-analytics-"
+  force_destroy = true
+}
+
+resource "aws_iam_role" "firehose" {
+  name               = "firehose-role"
+  assume_role_policy = data.aws_iam_policy_document.firehose_assume.json
+}
+
+resource "aws_iam_policy" "firehose_s3" {
+  name   = "firehose-s3-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject"
+        ]
+        Effect   = "Allow"
+        Resource = [
+          aws_s3_bucket.analytics.arn,
+          "${aws_s3_bucket.analytics.arn}/*"
+        ]
+      },
+      {
+        Action   = "lambda:InvokeFunction"
+        Effect   = "Allow"
+        Resource = aws_lambda_function.analytics_transformer.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "firehose_s3" {
+  role       = aws_iam_role.firehose.name
+  policy_arn = aws_iam_policy.firehose_s3.arn
+}
+
+resource "aws_lambda_function" "analytics_transformer" {
+  function_name = "analytics-transformer"
+  handler       = "analytics_transformer.lambda_handler"
+  runtime       = var.lambda_runtime
+  role          = aws_iam_role.lambda_exec.arn
+  filename      = "analytics_transformer_payload.zip"
+}
+
+resource "aws_lambda_permission" "allow_firehose" {
+  statement_id  = "AllowExecutionFromFirehose"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.analytics_transformer.function_name
+  principal     = "firehose.amazonaws.com"
+  source_arn    = aws_kinesis_firehose_delivery_stream.analytics.arn
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "analytics" {
+  name        = "analytics-stream"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.analytics.arn
+
+    processing_configuration {
+      enabled = true
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name  = "LambdaArn"
+          parameter_value = aws_lambda_function.analytics_transformer.arn
+        }
+      }
+    }
+  }
+}
+
+resource "aws_iam_policy" "firehose_write" {
+  name   = "firehose-write-policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action   = ["firehose:PutRecord"],
+      Effect   = "Allow",
+      Resource = aws_kinesis_firehose_delivery_stream.analytics.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_firehose" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.firehose_write.arn
+}
+

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -6,6 +6,11 @@ resource "aws_lambda_function" "this" {
   filename      = "lambda_function_payload.zip"
   memory_size   = 128
   timeout       = 15
+  environment {
+    variables = {
+      FIREHOSE_STREAM_NAME = aws_kinesis_firehose_delivery_stream.analytics.name
+    }
+  }
 }
 
 resource "aws_lambda_permission" "apigw" {

--- a/src/analytics_transformer.py
+++ b/src/analytics_transformer.py
@@ -1,0 +1,23 @@
+import base64
+import json
+from datetime import datetime, timezone
+
+
+def lambda_handler(event, context):
+    """Enrich Firehose records with a processed timestamp."""
+    output = []
+    for record in event.get("records", []):
+        payload = base64.b64decode(record["data"]).decode("utf-8")
+        data = json.loads(payload)
+        data["processed_at"] = datetime.now(timezone.utc).isoformat()
+        enriched = json.dumps(data) + "\n"
+        encoded = base64.b64encode(enriched.encode("utf-8")).decode("utf-8")
+        output.append(
+            {
+                "recordId": record["recordId"],
+                "result": "Ok",
+                "data": encoded,
+            }
+        )
+    return {"records": output}
+

--- a/tests/unit/test_analytics_transformer.py
+++ b/tests/unit/test_analytics_transformer.py
@@ -1,0 +1,22 @@
+import base64
+import json
+
+from src.analytics_transformer import lambda_handler
+
+
+def test_transformer_enriches_event():
+    payload = {"action": "test"}
+    encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+    event = {"records": [{"recordId": "1", "data": encoded}]}
+
+    result = lambda_handler(event, None)
+
+    assert "records" in result
+    record = result["records"][0]
+    assert record["recordId"] == "1"
+    assert record["result"] == "Ok"
+
+    out = json.loads(base64.b64decode(record["data"]).decode())
+    assert out["action"] == "test"
+    assert "processed_at" in out
+


### PR DESCRIPTION
## Summary
- Add analytics Firehose delivery stream backed by S3 with Lambda processing
- Pass Firehose stream name to application Lambda via environment variable
- Implement Lambda processor enriching analytics events and accompanying tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fa27dcf8832c87f0708947f64016