### PR TITLE
feat: enhance infra with secure API and observability

### DIFF
--- a/infra/apigw.tf
+++ b/infra/apigw.tf
@@ -1,25 +1,83 @@
-resource "aws_api_gateway_rest_api" "this" {
-  name = var.api_gateway_name
+resource "aws_apigatewayv2_api" "this" {
+  name                         = var.api_gateway_name
+  protocol_type                = "HTTP"
+  disable_execute_api_endpoint = true
 }
 
-resource "aws_api_gateway_resource" "proxy" {
-  rest_api_id = aws_api_gateway_rest_api.this.id
-  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
-  path_part   = "{proxy+}"
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.this.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.this.invoke_arn
+  payload_format_version = "2.0"
 }
 
-resource "aws_api_gateway_method" "proxy" {
-  rest_api_id   = aws_api_gateway_rest_api.this.id
-  resource_id   = aws_api_gateway_resource.proxy.id
-  http_method   = "ANY"
-  authorization = "NONE"
+resource "aws_apigatewayv2_authorizer" "cognito" {
+  api_id           = aws_apigatewayv2_api.this.id
+  authorizer_type  = "JWT"
+  name             = "cognito"
+  identity_sources = ["$request.header.Authorization"]
+
+  jwt_configuration {
+    audience = [aws_cognito_user_pool_client.this.id]
+    issuer   = aws_cognito_user_pool.this.endpoint
+  }
 }
 
-resource "aws_api_gateway_integration" "lambda" {
-  rest_api_id             = aws_api_gateway_rest_api.this.id
-  resource_id             = aws_api_gateway_resource.proxy.id
-  http_method             = aws_api_gateway_method.proxy.http_method
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.this.invoke_arn
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.this.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
 }
+
+resource "aws_cloudwatch_log_group" "api_gw" {
+  name              = "/aws/apigwv2/${var.api_gateway_name}"
+  retention_in_days = 14
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.this.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gw.arn
+    format = jsonencode({
+      requestId   = "$context.requestId",
+      ip          = "$context.identity.sourceIp",
+      requestTime = "$context.requestTime",
+      httpMethod  = "$context.httpMethod",
+      path        = "$context.path",
+      status      = "$context.status"
+    })
+  }
+}
+
+resource "aws_apigatewayv2_domain_name" "this" {
+  domain_name = var.custom_domain_name
+  domain_name_configuration {
+    certificate_arn = var.acm_certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "this" {
+  api_id      = aws_apigatewayv2_api.this.id
+  domain_name = aws_apigatewayv2_domain_name.this.domain_name
+  stage       = aws_apigatewayv2_stage.default.id
+}
+
+resource "aws_route53_record" "apigw_domain" {
+  zone_id = var.route53_zone_id
+  name    = aws_apigatewayv2_domain_name.this.domain_name
+  type    = "A"
+  alias {
+    name                   = aws_apigatewayv2_domain_name.this.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.this.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,0 +1,31 @@
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_name          = "${var.lambda_function_name}-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "Alarm if the Lambda function returns any errors"
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_5xx" {
+  alarm_name          = "${var.api_gateway_name}-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "Alarm if the API Gateway returns any 5XX errors"
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.this.id
+    Stage = aws_apigatewayv2_stage.default.name
+  }
+}
+

--- a/infra/cognito.tf
+++ b/infra/cognito.tf
@@ -1,3 +1,8 @@
 resource "aws_cognito_user_pool" "this" {
   name = var.cognito_user_pool_name
 }
+
+resource "aws_cognito_user_pool_client" "this" {
+  name         = "${var.cognito_user_pool_name}-client"
+  user_pool_id = aws_cognito_user_pool.this.id
+}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,16 +1,21 @@
 resource "aws_lambda_function" "this" {
   function_name = var.lambda_function_name
-  handler       = var.lambda_handler
-  runtime       = var.lambda_runtime
   role          = aws_iam_role.lambda_exec.arn
-  filename      = "lambda_function_payload.zip"
+  package_type  = "Image"
+  image_uri     = var.lambda_image_uri
   memory_size   = 128
   timeout       = 15
   environment {
     variables = {
       FIREHOSE_STREAM_NAME = aws_kinesis_firehose_delivery_stream.analytics.name
+      ROAM_API_SECRET_NAME = var.roam_api_secret_name
     }
   }
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = 14
 }
 
 resource "aws_lambda_permission" "apigw" {
@@ -18,5 +23,6 @@ resource "aws_lambda_permission" "apigw" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.this.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+  source_arn    = "${aws_apigatewayv2_api.this.execution_arn}/*/*"
 }
+

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -3,11 +3,19 @@ output "lambda_function_arn" {
 }
 
 output "api_gateway_id" {
-  value = aws_api_gateway_rest_api.this.id
+  value = aws_apigatewayv2_api.this.id
 }
 
 output "cognito_user_pool_id" {
   value = aws_cognito_user_pool.this.id
+}
+
+output "cognito_user_pool_client_id" {
+  value = aws_cognito_user_pool_client.this.id
+}
+
+output "api_domain_name" {
+  value = aws_apigatewayv2_domain_name.this.domain_name
 }
 
 output "iam_role_arn" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -23,18 +23,6 @@ variable "lambda_function_name" {
   default     = "pkm-function"
 }
 
-variable "lambda_handler" {
-  description = "Lambda handler"
-  type        = string
-  default     = "index.handler"
-}
-
-variable "lambda_runtime" {
-  description = "Runtime for the Lambda function"
-  type        = string
-  default     = "python3.11"
-}
-
 variable "api_gateway_name" {
   description = "Name of the API Gateway"
   type        = string
@@ -45,4 +33,34 @@ variable "cognito_user_pool_name" {
   description = "Name of the Cognito user pool"
   type        = string
   default     = "pkm-user-pool"
+}
+
+variable "lambda_image_uri" {
+  description = "ECR image URI for the Lambda function"
+  type        = string
+  default     = ""
+}
+
+variable "roam_api_secret_name" {
+  description = "Secrets Manager secret name for the ROAM API token"
+  type        = string
+  default     = ""
+}
+
+variable "custom_domain_name" {
+  description = "Custom domain name for the API Gateway"
+  type        = string
+  default     = "api.example.com"
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for the custom domain"
+  type        = string
+  default     = "arn:aws:acm:us-east-1:123456789012:certificate/example"
+}
+
+variable "route53_zone_id" {
+  description = "Route53 hosted zone ID for the custom domain"
+  type        = string
+  default     = "Z1234567890ABC"
 }

--- a/src/handler.py
+++ b/src/handler.py
@@ -8,9 +8,20 @@ from typing import Any, Dict
 import requests
 
 from .logger import log_event
+from . import token_loader
 
 ROAM_API_BASE = os.environ.get("ROAM_API_BASE", "http://0.0.0.0:8088")
 ROAM_API_TOKEN = os.environ.get("ROAM_API_TOKEN")
+_SECRET_NAME = os.environ.get("ROAM_API_SECRET_NAME")
+
+# Fetch the token from Secrets Manager if a secret name is provided and no token
+# was supplied directly via the ``ROAM_API_TOKEN`` environment variable.
+if _SECRET_NAME and not ROAM_API_TOKEN:
+    try:
+        secret_payload = token_loader.load(_SECRET_NAME)
+        ROAM_API_TOKEN = secret_payload.get("token")
+    except token_loader.TokenLoaderError:
+        ROAM_API_TOKEN = None
 
 
 def _proxy_to_roam(event: Dict[str, Any], path: str, method: str) -> Dict[str, Any]:

--- a/tests/unit/test_handler_secrets.py
+++ b/tests/unit/test_handler_secrets.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import token_loader
+
+
+def test_import_fetches_token_from_secret(monkeypatch):
+    monkeypatch.delenv("ROAM_API_TOKEN", raising=False)
+    monkeypatch.setenv("ROAM_API_SECRET_NAME", "my/secret")
+
+    called = {}
+
+    def fake_load(name):
+        called["name"] = name
+        return {"token": "abc123"}
+
+    monkeypatch.setattr(token_loader, "load", fake_load)
+    import src.handler as handler
+    importlib.reload(handler)
+
+    assert handler.ROAM_API_TOKEN == "abc123"
+    assert called["name"] == "my/secret"
+
+    monkeypatch.delenv("ROAM_API_SECRET_NAME", raising=False)
+    importlib.reload(handler)
+
+
+def test_import_handles_missing_secret(monkeypatch):
+    monkeypatch.delenv("ROAM_API_TOKEN", raising=False)
+    monkeypatch.setenv("ROAM_API_SECRET_NAME", "missing")
+
+    def fake_load(name):
+        raise token_loader.TokenLoaderError("not found")
+
+    monkeypatch.setattr(token_loader, "load", fake_load)
+    import src.handler as handler
+    importlib.reload(handler)
+
+    assert handler.ROAM_API_TOKEN is None
+
+    monkeypatch.delenv("ROAM_API_SECRET_NAME", raising=False)
+    importlib.reload(handler)


### PR DESCRIPTION
## Summary
- provision HTTP API Gateway with Cognito JWT authorizer, custom domain and logging
- move Lambda to Python 3.12 container image and read ROAM token from Secrets Manager
- add CloudWatch metrics and alarms for Lambda errors and API 5XX responses
- add unit tests covering token loading from Secrets Manager

## Testing
- `pytest -q`
- `terraform fmt -recursive infra`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6849c99b4832c833c70e89fcfae4d