### PR TITLE
Expand test suite with contract, integration, security, and performance checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pytest
 ruff
 black
 requests
+bandit
+pytest-benchmark

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared test configuration."""
+
+import sys
+from pathlib import Path
+
+# Ensure project root is available on ``sys.path`` for nested tests.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/contract/test_analytics_transformer_contract.py
+++ b/tests/contract/test_analytics_transformer_contract.py
@@ -1,0 +1,27 @@
+"""Contract tests for the analytics transformer."""
+
+import base64
+import json
+
+from src.analytics_transformer import lambda_handler
+
+
+def test_firehose_transformation_contract():
+    """Ensure Firehose transformer output matches expected schema."""
+    payload = {"action": "contract"}
+    encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+    event = {"records": [{"recordId": "1", "data": encoded}]}
+
+    result = lambda_handler(event, None)
+
+    assert "records" in result
+    assert len(result["records"]) == 1
+    record = result["records"][0]
+    # contract: record contains id, result status, and data
+    assert set(record.keys()) == {"recordId", "result", "data"}
+    assert record["recordId"] == "1"
+    assert record["result"] == "Ok"
+
+    decoded = json.loads(base64.b64decode(record["data"]).decode())
+    assert decoded["action"] == "contract"
+    assert "processed_at" in decoded

--- a/tests/integration/test_handler_proxy_integration.py
+++ b/tests/integration/test_handler_proxy_integration.py
@@ -1,0 +1,45 @@
+"""Integration tests for the handler proxy behaviour."""
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from src import handler
+
+
+class _RoamHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802  (method name from BaseHTTPRequestHandler)
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{"status": "ok"}')
+
+    def log_message(self, format, *args):  # noqa: D401,N803
+        """Silence default logging."""
+        return
+
+
+def test_proxy_to_roam_integration():
+    """Proxy request should reach the external service and return its response."""
+    server = HTTPServer(("127.0.0.1", 0), _RoamHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    port = server.server_port
+    old_base = handler.ROAM_API_BASE
+    handler.ROAM_API_BASE = f"http://127.0.0.1:{port}"
+    try:
+        event = {
+            "rawPath": "/roam_test",
+            "requestContext": {"http": {"method": "GET"}},
+            "rawQueryString": "",
+            "headers": {},
+        }
+        result = handler.lambda_handler(event, None)
+    finally:
+        server.shutdown()
+        handler.ROAM_API_BASE = old_base
+
+    assert result["statusCode"] == 200
+    assert json.loads(result["body"]) == {"status": "ok"}

--- a/tests/performance/test_analytics_transformer_performance.py
+++ b/tests/performance/test_analytics_transformer_performance.py
@@ -1,0 +1,22 @@
+"""Performance tests for the analytics transformer."""
+
+import base64
+import json
+
+from src.analytics_transformer import lambda_handler
+
+
+def _build_event(n=100):
+    records = []
+    for i in range(n):
+        payload = {"id": i}
+        encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+        records.append({"recordId": str(i), "data": encoded})
+    return {"records": records}
+
+
+def test_analytics_transformer_performance(benchmark):
+    """Benchmark the transformer with a larger payload."""
+    event = _build_event(100)
+    result = benchmark(lambda_handler, event, None)
+    assert len(result["records"]) == 100

--- a/tests/security/test_bandit_scan.py
+++ b/tests/security/test_bandit_scan.py
@@ -1,0 +1,11 @@
+"""Security scanning tests using Bandit."""
+
+import subprocess
+
+
+def test_bandit_security_scan():
+    """Run Bandit security scanner over the source tree."""
+    result = subprocess.run(
+        ["bandit", "-q", "-r", "src"], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- add Bandit and pytest-benchmark dependencies
- introduce contract, integration, security, and performance test suites
- ensure tests can import project modules via shared `conftest`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68b4920b4832c84c838d4262b12ec