### PR TITLE
feat: improve error handling and coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,17 @@ See [docs/architecture.md](docs/architecture.md) for a detailed overview of the 
 
 ## Development
 
-   
-### Project Structure   
+
+### Coding standards
+
+This project targets **Python 3.12** and uses **Ruff** for linting and **Black** for
+formatting. All API errors follow [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)
+problem details and unexpected exceptions are logged for observability. Each error
+response includes a correlation identifier that is also emitted in logs to aid in
+troubleshooting.
+
+
+### Project Structure
 ```
 /infra  - infrastructure-as-code
 /src    - Lambda application source
@@ -39,7 +48,7 @@ Copy `.env.example` to `.env` and provide the values for the variables below:
 
 ### Local development
 
-1. Install dependencies:
+1. Install dependencies (requires Python 3.12):
    ```bash
    python -m pip install -r requirements.txt
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">=3.12"
+
 [tool.black]
 line-length = 88
 target-version = ['py312']

--- a/src/analytics_transformer.py
+++ b/src/analytics_transformer.py
@@ -20,4 +20,3 @@ def lambda_handler(event, context):
             }
         )
     return {"records": output}
-

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,18 +1,46 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict
 
 import requests
 
-from .logger import log_event
 from . import token_loader
+from .logger import log_event
 
 ROAM_API_BASE = os.environ.get("ROAM_API_BASE", "http://0.0.0.0:8088")
 ROAM_API_TOKEN = os.environ.get("ROAM_API_TOKEN")
 _SECRET_NAME = os.environ.get("ROAM_API_SECRET_NAME")
+
+
+logger = logging.getLogger(__name__)
+
+
+class RequestIdFilter(logging.Filter):
+    """Attach a request identifier to all log records."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.request_id = "-"
+
+    def set(self, request_id: str) -> None:
+        self.request_id = request_id
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.request_id = self.request_id
+        return True
+
+
+_request_id_filter = RequestIdFilter()
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(levelname)s %(name)s [%(request_id)s] %(message)s",
+)
+logging.getLogger().addFilter(_request_id_filter)
 
 # Fetch the token from Secrets Manager if a secret name is provided and no token
 # was supplied directly via the ``ROAM_API_TOKEN`` environment variable.
@@ -22,6 +50,28 @@ if _SECRET_NAME and not ROAM_API_TOKEN:
         ROAM_API_TOKEN = secret_payload.get("token")
     except token_loader.TokenLoaderError:
         ROAM_API_TOKEN = None
+
+
+def _problem_response(
+    status: int,
+    title: str,
+    detail: str,
+    type_: str = "about:blank",
+    instance: str | None = None,
+) -> Dict[str, Any]:
+    body = {
+        "type": type_,
+        "title": title,
+        "status": status,
+        "detail": detail,
+    }
+    if instance:
+        body["instance"] = instance
+    return {
+        "statusCode": status,
+        "headers": {"Content-Type": "application/problem+json"},
+        "body": json.dumps(body),
+    }
 
 
 def _proxy_to_roam(event: Dict[str, Any], path: str, method: str) -> Dict[str, Any]:
@@ -43,48 +93,71 @@ def _proxy_to_roam(event: Dict[str, Any], path: str, method: str) -> Dict[str, A
         headers["Content-Type"] = "application/json"
     body = event.get("body")
     response = requests.request(method, url, data=body, headers=headers)
+    if response.status_code >= 400:
+        logger.error("ROAM API error %s %s -> %s", method, url, response.status_code)
     return {"statusCode": response.status_code, "body": response.text}
+
+
+def _get_request_id(event: Dict[str, Any], context: Any) -> str:
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    return headers.get("x-request-id") or getattr(
+        context, "aws_request_id", str(uuid.uuid4())
+    )
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Basic router for Lambda events."""
-    path = event.get("rawPath") or event.get("path")
-    method = event.get("requestContext", {}).get("http", {}).get("method") or event.get(
-        "httpMethod"
-    )
+    request_id = _get_request_id(event, context)
+    _request_id_filter.set(request_id)
+    try:
+        path = event.get("rawPath") or event.get("path")
+        method = event.get("requestContext", {}).get("http", {}).get(
+            "method"
+        ) or event.get("httpMethod")
+        logger.info("Handling %s %s", method, path)
 
-    if path and path.startswith("/roam_"):
-        return _proxy_to_roam(event, path, method)
+        if path and path.startswith("/roam_"):
+            return _proxy_to_roam(event, path, method)
 
-    if method == "POST" and path == "/analytics/log":
-        body = event.get("body")
-        try:
-            payload = json.loads(body or "{}")
-        except json.JSONDecodeError:
+        if method == "POST" and path == "/analytics/log":
+            body = event.get("body")
+            try:
+                payload = json.loads(body or "{}")
+            except json.JSONDecodeError:
+                return _problem_response(
+                    400,
+                    "Bad Request",
+                    "Invalid JSON",
+                    instance=f"urn:uuid:{request_id}",
+                )
+
+            user_id = (
+                event.get("requestContext", {})
+                .get("authorizer", {})
+                .get("claims", {})
+                .get("sub")
+            )
+
+            data = {
+                "user_id": user_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "payload": payload,
+            }
+            log_event(data)
             return {
-                "statusCode": 400,
-                "body": json.dumps({"detail": "Invalid JSON"}),
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"status": "ok"}),
             }
 
-        user_id = (
-            event.get("requestContext", {})
-            .get("authorizer", {})
-            .get("claims", {})
-            .get("sub")
+        return _problem_response(
+            404, "Not Found", "Not found", instance=f"urn:uuid:{request_id}"
         )
-
-        data = {
-            "user_id": user_id,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "payload": payload,
-        }
-        log_event(data)
-        return {
-            "statusCode": 200,
-            "body": json.dumps({"status": "ok"}),
-        }
-
-    return {
-        "statusCode": 404,
-        "body": json.dumps({"detail": "Not found"}),
-    }
+    except Exception:  # pragma: no cover - safety net
+        logger.exception("Unhandled error")
+        return _problem_response(
+            500,
+            "Internal Server Error",
+            "Internal server error",
+            instance=f"urn:uuid:{request_id}",
+        )

--- a/tests/integration/test_handler_proxy_integration.py
+++ b/tests/integration/test_handler_proxy_integration.py
@@ -1,7 +1,6 @@
 """Integration tests for the handler proxy behaviour."""
 
 import json
-import os
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,55 @@
+import json
+import logging
+
+from src import handler
+
+
+def test_invalid_json_returns_rfc7807():
+    event = {
+        "rawPath": "/analytics/log",
+        "body": "{invalid",
+        "requestContext": {"http": {"method": "POST"}},
+    }
+    resp = handler.lambda_handler(event, None)
+    assert resp["statusCode"] == 400
+    assert resp["headers"]["Content-Type"] == "application/problem+json"
+    body = json.loads(resp["body"])
+    assert body["title"] == "Bad Request"
+    assert body["status"] == 400
+    assert body["instance"]
+
+
+def test_not_found_returns_rfc7807():
+    event = {"rawPath": "/missing", "requestContext": {"http": {"method": "GET"}}}
+    resp = handler.lambda_handler(event, None)
+    assert resp["statusCode"] == 404
+    body = json.loads(resp["body"])
+    assert body["title"] == "Not Found"
+    assert body["status"] == 404
+    assert body["instance"]
+
+
+def test_exception_handling_logs_and_returns_problem(monkeypatch, caplog):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(handler, "_proxy_to_roam", boom)
+    event = {"rawPath": "/roam_boom", "requestContext": {"http": {"method": "GET"}}}
+    caplog.set_level(logging.ERROR)
+    resp = handler.lambda_handler(event, None)
+    assert resp["statusCode"] == 500
+    body = json.loads(resp["body"])
+    assert body["title"] == "Internal Server Error"
+    assert "Unhandled error" in caplog.text
+    assert body["instance"]
+
+
+def test_request_id_header_propagated():
+    event = {
+        "rawPath": "/missing",
+        "requestContext": {"http": {"method": "GET"}},
+        "headers": {"X-Request-Id": "abc-123"},
+    }
+    resp = handler.lambda_handler(event, None)
+    body = json.loads(resp["body"])
+    assert body["instance"].endswith("abc-123")

--- a/tests/unit/test_analytics_transformer.py
+++ b/tests/unit/test_analytics_transformer.py
@@ -19,4 +19,3 @@ def test_transformer_enriches_event():
     out = json.loads(base64.b64decode(record["data"]).decode())
     assert out["action"] == "test"
     assert "processed_at" in out
-

--- a/tests/unit/test_handler_secrets.py
+++ b/tests/unit/test_handler_secrets.py
@@ -4,8 +4,6 @@ import importlib
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src import token_loader
@@ -23,6 +21,7 @@ def test_import_fetches_token_from_secret(monkeypatch):
 
     monkeypatch.setattr(token_loader, "load", fake_load)
     import src.handler as handler
+
     importlib.reload(handler)
 
     assert handler.ROAM_API_TOKEN == "abc123"
@@ -41,6 +40,7 @@ def test_import_handles_missing_secret(monkeypatch):
 
     monkeypatch.setattr(token_loader, "load", fake_load)
     import src.handler as handler
+
     importlib.reload(handler)
 
     assert handler.ROAM_API_TOKEN is None


### PR DESCRIPTION
## Summary
- enforce Python 3.12 and document Ruff/Black coding standards
- add RFC 7807 problem responses with global exception logging
- correlate request IDs across logs and problem responses
- cover error cases with tests and format codebase

## Testing
- `ruff check .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a68df08ad0832c8c508e46d2983cf0